### PR TITLE
Be consistent with double/float usage

### DIFF
--- a/Catalano.Image/src/Catalano/Imaging/Concurrent/Filters/HSLFiltering.java
+++ b/Catalano.Image/src/Catalano/Imaging/Concurrent/Filters/HSLFiltering.java
@@ -258,7 +258,7 @@ public class HSLFiltering implements IApplyInPlace{
                     int g = share.fastBitmap.getGreen(i, j);
                     int b = share.fastBitmap.getBlue(i, j);
                     
-                    float[] hsl = ColorConverter.RGBtoHLS(r, g, b);
+                    double[] hsl = ColorConverter.RGBtoHLS(r, g, b);
                     
                     // check HSL values
                     if (

--- a/Catalano.Image/src/Catalano/Imaging/Concurrent/Filters/YCbCrFiltering.java
+++ b/Catalano.Image/src/Catalano/Imaging/Concurrent/Filters/YCbCrFiltering.java
@@ -259,7 +259,7 @@ public class YCbCrFiltering implements IApplyInPlace{
                     int b = share.fastBitmap.getBlue(i, j);
                     
                     // convert to YCbCr
-                    float[] ycbcr = ColorConverter.RGBtoYCbCr(r, g, b, ColorConverter.YCbCrColorSpace.ITU_BT_601);
+                    double[] ycbcr = ColorConverter.RGBtoYCbCr(r, g, b, ColorConverter.YCbCrColorSpace.ITU_BT_601);
 
                     // check YCbCr values
                     if (

--- a/Catalano.Image/src/Catalano/Imaging/Filters/ExtractYCbCrChannel.java
+++ b/Catalano.Image/src/Catalano/Imaging/Filters/ExtractYCbCrChannel.java
@@ -78,7 +78,7 @@ public class ExtractYCbCrChannel implements IApplyInPlace{
             FastBitmap l = new FastBitmap(width, height, FastBitmap.ColorSpace.Grayscale);
             
             int r,g,b;
-            float[] ycbcr;
+            double[] ycbcr;
             switch(YCbCr){
                 case Y:
                     for (int x = 0; x < height; x++) {

--- a/Catalano.Image/src/Catalano/Imaging/Filters/HSLFiltering.java
+++ b/Catalano.Image/src/Catalano/Imaging/Filters/HSLFiltering.java
@@ -216,7 +216,7 @@ public class HSLFiltering implements IApplyInPlace{
                 int g = fastBitmap.getGreen(i);
                 int b = fastBitmap.getBlue(i);
 
-                float[] hsl = ColorConverter.RGBtoHLS(r, g, b);
+                double[] hsl = ColorConverter.RGBtoHLS(r, g, b);
 
                 // check HSL values
                 if (

--- a/Catalano.Image/src/Catalano/Imaging/Filters/HSLLinear.java
+++ b/Catalano.Image/src/Catalano/Imaging/Filters/HSLLinear.java
@@ -140,7 +140,7 @@ public class HSLLinear implements IApplyInPlace{
                 int g = fastBitmap.getGreen(i);
                 int b = fastBitmap.getBlue(i);
 
-                float[] hsl = ColorConverter.RGBtoHLS(r, g, b);
+                double[] hsl = ColorConverter.RGBtoHLS(r, g, b);
 
                 // do luminance correction
                 if ( hsl[2] >= inLuminance.getMax() )

--- a/Catalano.Image/src/Catalano/Imaging/Filters/HueModifier.java
+++ b/Catalano.Image/src/Catalano/Imaging/Filters/HueModifier.java
@@ -68,7 +68,7 @@ public class HueModifier implements IApplyInPlace{
                 int g = fastBitmap.getGreen(i);
                 int b = fastBitmap.getBlue(i);
                 
-                float[] color = ColorConverter.RGBtoHLS(r, g, b);
+                double[] color = ColorConverter.RGBtoHLS(r, g, b);
                 int[] newColor = ColorConverter.HSLtoRGB(degree,color[1],color[2]);
                 
                 newColor[0] = newColor[0] > 255 ? 255 : newColor[0];

--- a/Catalano.Image/src/Catalano/Imaging/Filters/YCbCrFiltering.java
+++ b/Catalano.Image/src/Catalano/Imaging/Filters/YCbCrFiltering.java
@@ -217,7 +217,7 @@ public class YCbCrFiltering implements IApplyInPlace{
                 int b = fastBitmap.getBlue(i);
 
                 // convert to YCbCr
-                float[] ycbcr = ColorConverter.RGBtoYCbCr(r, g, b, ColorConverter.YCbCrColorSpace.ITU_BT_601);
+                double[] ycbcr = ColorConverter.RGBtoYCbCr(r, g, b, ColorConverter.YCbCrColorSpace.ITU_BT_601);
 
                 // check YCbCr values
                 if (


### PR DESCRIPTION
Several YCbCr / HSL values were inconsistently using either `double[]` or `float[]`, causing errors.  Switch them all to `double[]`.